### PR TITLE
Improve templating support

### DIFF
--- a/hooks/post-command
+++ b/hooks/post-command
@@ -40,7 +40,7 @@ if [[ -n "${BUILDKITE_PLUGIN_CACHE_CACHE_KEY:-}" ]]; then
 
   if [[ $TEMPLATE_VALUE == *"checksum"* ]]; then
     TARGET="$(echo -e "${TEMPLATE_VALUE/"checksum"/""}" | tr -d \' | tr -d \" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
-    RESULT=$(find "$TARGET" -type f | xargs -d'\n' -P0 -n1 $HASHER_BIN | sort -k 2 | $HASHER_BIN | awk '{print $1}')
+    RESULT=$(find "$TARGET" -type f -exec $HASHER_BIN {} \; | sort -k 2 | $HASHER_BIN | awk '{print $1}')
     CACHE_KEY="$CACHE_KEY_PREFIX$RESULT"
   else
     CACHE_KEY=$BUILDKITE_PLUGIN_CACHE_CACHE_KEY

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -35,16 +35,18 @@ if [[ -n "${BUILDKITE_PLUGIN_CACHE_CACHE_KEY:-}" ]]; then
     AWS_ARGS="--profile ${BUILDKITE_PLUGIN_CACHE_S3_PROFILE}"
   fi
 
-  CACHE_KEY_PREFIX=$(echo "$BUILDKITE_PLUGIN_CACHE_CACHE_KEY" | sed -e 's/{.*//')
-  TEMPLATE_VALUE=$(echo "$BUILDKITE_PLUGIN_CACHE_CACHE_KEY" | sed -e 's/^[^\{{]*[^A-Za-z]*//' -e 's/.}}.*$//' | tr -d \' | tr -d \")
-
-  if [[ $TEMPLATE_VALUE == *"checksum"* ]]; then
-    TARGET="$(echo -e "${TEMPLATE_VALUE/"checksum"/""}" | tr -d \' | tr -d \" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
-    RESULT=$(find "$TARGET" -type f -exec $HASHER_BIN {} \; | sort -k 2 | $HASHER_BIN | awk '{print $1}')
-    CACHE_KEY="$CACHE_KEY_PREFIX$RESULT"
-  else
-    CACHE_KEY=$BUILDKITE_PLUGIN_CACHE_CACHE_KEY
-  fi
+  CACHE_KEY="$BUILDKITE_PLUGIN_CACHE_CACHE_KEY"
+  while [[ "$CACHE_KEY" =~ (.*)\{\{\ *(.*)\ *\}\}(.*) ]]; do
+    TEMPLATE_VALUE="${BASH_REMATCH[2]}"
+    EXPANDED_VALUE=""
+    if [[ $TEMPLATE_VALUE == *"checksum"* ]]; then
+      TARGET="$(echo -e "${TEMPLATE_VALUE/"checksum"/""}" | tr -d \' | tr -d \" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+      EXPANDED_VALUE=$(find "$TARGET" -type f -exec $HASHER_BIN {} \; | sort -k 2 | $HASHER_BIN | awk '{print $1}')
+    else
+      echo "Invalid template expression: $TEMPLATE_VALUE"; exit 1
+    fi
+    CACHE_KEY="${BASH_REMATCH[1]}${EXPANDED_VALUE}${BASH_REMATCH[3]}"
+  done
 
   paths=()
 

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -34,7 +34,7 @@ if [[ -n "${BUILDKITE_PLUGIN_CACHE_CACHE_KEY:-}" ]]; then
   TEMPLATE_VALUE=$(echo "$BUILDKITE_PLUGIN_CACHE_CACHE_KEY" | sed -e 's/^[^\{{]*[^A-Za-z]*//' -e 's/.}}.*$//' | tr -d \' | tr -d \")
   if [[ $TEMPLATE_VALUE == *"checksum"* ]]; then
     TARGET="$(echo -e "${TEMPLATE_VALUE/"checksum"/""}" | tr -d \' | tr -d \" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
-    RESULT=$(find "$TARGET" -type f | xargs -d'\n' -P0 -n1 $HASHER_BIN | sort -k 2 | $HASHER_BIN | awk '{print $1}')
+    RESULT=$(find "$TARGET" -type f -exec $HASHER_BIN {} \; | sort -k 2 | $HASHER_BIN | awk '{print $1}')
     CACHE_KEY="$CACHE_KEY_PREFIX$RESULT"
   else
     CACHE_KEY=$BUILDKITE_PLUGIN_CACHE_CACHE_KEY

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -30,15 +30,19 @@ if [[ -n "${BUILDKITE_PLUGIN_CACHE_CACHE_KEY:-}" ]]; then
     AWS_ARGS="--profile ${BUILDKITE_PLUGIN_CACHE_S3_PROFILE}"
   fi
 
-  CACHE_KEY_PREFIX=$(echo "$BUILDKITE_PLUGIN_CACHE_CACHE_KEY" | sed -e 's/{.*//')
-  TEMPLATE_VALUE=$(echo "$BUILDKITE_PLUGIN_CACHE_CACHE_KEY" | sed -e 's/^[^\{{]*[^A-Za-z]*//' -e 's/.}}.*$//' | tr -d \' | tr -d \")
-  if [[ $TEMPLATE_VALUE == *"checksum"* ]]; then
-    TARGET="$(echo -e "${TEMPLATE_VALUE/"checksum"/""}" | tr -d \' | tr -d \" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
-    RESULT=$(find "$TARGET" -type f -exec $HASHER_BIN {} \; | sort -k 2 | $HASHER_BIN | awk '{print $1}')
-    CACHE_KEY="$CACHE_KEY_PREFIX$RESULT"
-  else
-    CACHE_KEY=$BUILDKITE_PLUGIN_CACHE_CACHE_KEY
-  fi
+  # Resolve all template blocks in the cache key.
+  CACHE_KEY="$BUILDKITE_PLUGIN_CACHE_CACHE_KEY"
+  while [[ "$CACHE_KEY" =~ (.*)\{\{\ *(.*)\ *\}\}(.*) ]]; do
+    TEMPLATE_VALUE="${BASH_REMATCH[2]}"
+    EXPANDED_VALUE=""
+    if [[ $TEMPLATE_VALUE == *"checksum"* ]]; then
+      TARGET="$(echo -e "${TEMPLATE_VALUE/"checksum"/""}" | tr -d \' | tr -d \" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+      EXPANDED_VALUE=$(find "$TARGET" -type f -exec $HASHER_BIN {} \; | sort -k 2 | $HASHER_BIN | awk '{print $1}')
+    else
+      echo "Invalid template expression: $TEMPLATE_VALUE"; exit 1
+    fi
+    CACHE_KEY="${BASH_REMATCH[1]}${EXPANDED_VALUE}${BASH_REMATCH[3]}"
+  done
 
   echo "🔍 Looking for $CACHE_KEY"
 


### PR DESCRIPTION
The existing logic assumes that a checksum template will occur last in the cache key and ignores everything after the first template block. This isn't really mentioned as a limitation in the documentation, and means that a key specified like `v1-cache-{{ checksum 'foo.lock' }}-{{ checksum 'bar.lock' }}-some-more-stuff` actually translates to just the result of `v1-cache-{{ checksum 'foo.lock' }}`.

This PR changes the logic to evaluate all template blocks and preserves anything after the last template block. It also makes unsupported template blocks an error. Previously, these were passed through untouched, but that could hide bugs like this typo `{{ cheksum 'foo.lock' }}` which would silently fail to compute a checksum. Therefore, this PR is conceivably a breaking change for some folks relying on unsupported template blocks to be passed through literally, but this seems unlikely to be the desired behavior.

This PR is built on top of https://github.com/gencer/cache-buildkite-plugin/pull/8 since it touches the same lines.

