### PR TITLE
Don't upload unconditionally to S3

### DIFF
--- a/lib/backends/s3.bash
+++ b/lib/backends/s3.bash
@@ -81,8 +81,8 @@ function cache() {
       TMP_FILE="$(mktemp)"
       tar $BK_TAR_ARGS "${TMP_FILE}" "${paths[*]}"
       mv -f "${TMP_FILE}" "${TAR_FILE}"
+      aws s3 cp $BK_AWS_ARGS "$TAR_FILE" "s3://${BUCKET}/${TAR_FILE}"
     fi
-    aws s3 cp $BK_AWS_ARGS "$TAR_FILE" "s3://${BUCKET}/${TAR_FILE}"
     rm -f "${TAR_FILE}"
 
   elif
@@ -94,8 +94,8 @@ function cache() {
       TMP_FILE="$(mktemp)"
       tar $BK_TAR_ARGS "${TMP_FILE}" "${paths[@]}"
       mv -f "${TMP_FILE}" "${TAR_FILE}"
+      aws s3 cp $BK_AWS_ARGS "${TAR_FILE}" "s3://${BUCKET}/${TAR_FILE}"
     fi
-    aws s3 cp $BK_AWS_ARGS "${TAR_FILE}" "s3://${BUCKET}/${TAR_FILE}"
     rm -f "${TAR_FILE}"
   fi
 }


### PR DESCRIPTION
Only upload if new tar file was created.

As of now plugin uploads every time, even if cache content hasn't changed.