### PR TITLE
Fix advanced example where `plugins:` has to be array

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,15 +344,15 @@ steps:
     key: test
     command: yarn test --runInBand && bundle exec rspec --color
     plugins:
-      <<: *caches
-      docker#v3.7.0: ~ # Use your config here
+      *caches
+      - docker#v3.7.0: ~ # Use your config here
   - name: ':istanbul: Run Istanbul'
     key: istanbul
     depends_on: test
     command: .buildkite/steps/istanbul.sh
     plugins:
-      <<: *caches
-      docker#v3.7.0: ~ # Use your config here
+      *caches
+      - docker#v3.7.0: ~ # Use your config here
 ```
 
 ## Usage with docker


### PR DESCRIPTION
This PR fixes the advanced example in `README.md` where previously using `<<: *caches` yielded an object which collapses all plugins into a single field (`"gencer/cache#v2.4.8"`)also buildkite rejecting that definition; after the change it creates an array of plugin definitions as required by buildkite.