### PR TITLE
Add support for reading env variables in cache key template

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,7 @@ the cache key will be determined by executing a _checksum_ (actually `sha1sum`) 
 | `checksum 'file_name'` - or -<br />`checksum './directory'` | File: sha1 of that file<br />Directory: **sorted** hashing of the whole directory. |
 | `git.branch`                                                | For example: `master`.<br />Derived from `${BUILDKITE_BRANCH}`                     |
 | `git.commit`                                                | For example: `9576a34...`. (Full SHA).<br />Derived from `${BUILDKITE_COMMIT}`     |
+| `env.FOO`                                                   | Value in environment variable `FOO`                                                |
 
 ## Hashing (checksum) against directory
 

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -23,6 +23,10 @@ function expand_templates() {
       TARGET="$(echo -e "${TEMPLATE_VALUE/"checksum"/""}" | tr -d \' | tr -d \" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
       EXPANDED_VALUE=$(find "$TARGET" -type f -exec $HASHER_BIN {} \; | sort -k 2 | $HASHER_BIN | awk '{print $1}')
       ;;
+    "env."*)
+      ENV_VAR_NAME="$(echo -e "${TEMPLATE_VALUE/"env."/""}" | tr -d \' | tr -d \" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+      EXPANDED_VALUE="${!ENV_VAR_NAME}"
+      ;;
     "git.branch"*)
       BRANCH="${BUILDKITE_BRANCH}"
       EXPANDED_VALUE="${BRANCH//\//_}"

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -1,11 +1,13 @@
 #!/usr/bin/env bats
 
-load "$BATS_PATH/load.bash"
+setup() {
+  load "$BATS_PLUGIN_PATH/load.bash"
 
-# Uncomment to enable stub debugging
-# export AWS_STUB_DEBUG=/dev/tty
-# export GIT_STUB_DEBUG=/dev/tty
-# export TAR_STUB_DEBUG=/dev/tty
+  # Uncomment to enable stub debugging
+  # export AWS_STUB_DEBUG=/dev/tty
+  # export GIT_STUB_DEBUG=/dev/tty
+  # export TAR_STUB_DEBUG=/dev/tty
+}
 
 @test "Pre-command restores cache with basic key" {
 

--- a/tests/lib.bats
+++ b/tests/lib.bats
@@ -1,0 +1,28 @@
+#!/usr/bin/env bats
+
+load "$BATS_PATH/load.bash"
+
+shared_lib="$PWD/lib/shared.bash"
+
+@test "expand_templates expands an environment variable" {
+  source $shared_lib
+
+  export FOO=bar 
+  cache_key="v1-{{ env.FOO }}-cache"
+
+  run expand_templates "${cache_key}"
+
+  assert_success
+  assert_output "v1-bar-cache"
+}
+
+@test "expand_templates produces output for missing environment variable" {
+  source $shared_lib
+
+  cache_key="v1-{{ env.BAZ }}-cache"
+
+  run expand_templates "${cache_key}"
+
+  assert_success
+  assert_output "v1--cache"
+}

--- a/tests/lib.bats
+++ b/tests/lib.bats
@@ -1,6 +1,8 @@
 #!/usr/bin/env bats
 
-load "$BATS_PATH/load.bash"
+setup() {
+  load "$BATS_PLUGIN_PATH/load.bash"
+}
 
 shared_lib="$PWD/lib/shared.bash"
 


### PR DESCRIPTION
We have a particular use case which requires part of the cache key to be defined at runtime. This PR adds support for this.