### PR TITLE
Remove existing tar file when cache always is set to true

### DIFF
--- a/lib/backends/s3.bash
+++ b/lib/backends/s3.bash
@@ -6,6 +6,7 @@ BK_CUSTOM_AWS_ARGS=""
 BK_CACHE_COMPRESS=${BUILDKITE_PLUGIN_CACHE_COMPRESS:-false}
 BK_CACHE_COMPRESS_PROGRAM=${BUILDKITE_PLUGIN_CACHE_COMPRESS_PROGRAM:-gzip}
 BK_CACHE_SAVE_CACHE=${BUILDKITE_PLUGIN_CACHE_S3_SAVE_CACHE:-false}
+BK_ALWAYS_CACHE=${BUILDKITE_PLUGIN_CACHE_ALWAYS:-false}
 BK_CACHE_LOCAL_PATH="/tmp"
 BK_TAR_ARGS=()
 BK_TAR_ADDITIONAL_ARGS="--ignore-failed-read"
@@ -134,6 +135,12 @@ function cache() {
 
   cache_locating "${TAR_TARGETS}"
   TAR_FILE="${CACHE_KEY}.${BK_TAR_EXTENSION}"
+
+  if [ $BK_ALWAYS_CACHE == "true" ]; then
+    echo -e "${BK_LOG_PREFIX}:file_cabinet::close: Removing previously found cache ${TAR_FILE} since always is true."
+    rm -f "${TAR_FILE}"
+  fi
+
   if [ ! -f "$TAR_FILE" ]; then
     TMP_FILE="$(mktemp)"
     tar "${BK_TAR_ARGS[@]}" "${TMP_FILE}" ${TAR_TARGETS}

--- a/lib/backends/tarball.bash
+++ b/lib/backends/tarball.bash
@@ -2,6 +2,7 @@
 
 # Defaults...
 BK_CACHE_COMPRESS=${BUILDKITE_PLUGIN_CACHE_COMPRESS:-false}
+BK_ALWAYS_CACHE=${BUILDKITE_PLUGIN_CACHE_ALWAYS:-false}
 BK_TAR_ARGS=()
 BK_TAR_ADDITIONAL_ARGS="--ignore-failed-read"
 BK_TAR_EXTENSION="tar"
@@ -112,6 +113,12 @@ function cache() {
   cache_locating "${TAR_TARGETS}"
   mkdir -p "${CACHE_PREFIX}"
   TAR_FILE="${CACHE_PREFIX}/${CACHE_KEY}.${BK_TAR_EXTENSION}"
+
+  if [ $BK_ALWAYS_CACHE == "true" ]; then
+    echo -e "${BK_LOG_PREFIX}:file_cabinet::close: Removing previously found cache ${TAR_FILE} since always is true."
+    rm -f "${TAR_FILE}"
+  fi
+
   if [ ! -f "$TAR_FILE" ]; then
     TMP_FILE="$(mktemp)"
     tar "${BK_TAR_ARGS[@]}" "${TMP_FILE}" ${TAR_TARGETS}

--- a/plugin.yml
+++ b/plugin.yml
@@ -21,6 +21,8 @@ configuration:
       type: [string]
     continue_on_error:
       type: boolean
+    always:
+      type: boolean
     pipeline-slug-override:
       type: string
     pr:


### PR DESCRIPTION
Adding a new optional argument to always cache the new tarball even when a hit. This is accomplished by removing the existing tarball when caching the data.

Resolves #46