### PR TITLE
add date formats to templates

### DIFF
--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -23,6 +23,10 @@ function expand_templates() {
       TARGET="$(echo -e "${TEMPLATE_VALUE/"checksum"/""}" | tr -d \' | tr -d \" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
       EXPANDED_VALUE=$(find "$TARGET" -type f -exec $HASHER_BIN {} \; | sort -k 2 | $HASHER_BIN | awk '{print $1}')
       ;;
+    "date "*)
+      DATE_FMT="$(echo -e "${TEMPLATE_VALUE/"date"/""}" | tr -d \' | tr -d \" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+      EXPANDED_VALUE=$(date "${DATE_FMT}")
+      ;;
     "env."*)
       ENV_VAR_NAME="$(echo -e "${TEMPLATE_VALUE/"env."/""}" | tr -d \' | tr -d \" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
       EXPANDED_VALUE="${!ENV_VAR_NAME}"


### PR DESCRIPTION
I wanted a cache to easily expire every month (and get rebuilt), so it was helpful to have `date` as a template option, eg:
```
  key: "z1-cache-{{ id }}-{{ runner.os }}-{{ checksum 'yarn.lock' }}-{{ date '+%Y-%m'}}"
```