### PR TITLE
Fix typos and update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ steps:
           class: STANDARD # Optional. Defaults to empty which is usually STANDARD or based on policy.
           args: '--option 1' # Optional. Defaults to empty. Any optional argument that can be passed to aws s3 cp command.
           save-cache: true # Optional. Saves the cache on temp folder and keep between builds/jobs on the same machine.
+          save-cache-dir: /mnt/cache # Optional. Where to save the cache if `save-cache` is enabled.
         paths:
           - 'bundle/vendor'
 ```
@@ -517,6 +518,7 @@ steps:
         s3:
           bucket: s3-bucket
           save-cache: true # Optional. Saves the cache on temp folder and keep between builds/jobs on the same machine. Defaults to `false`
+          save-cache-dir: /mnt/cache # Optional. Where to save the cache if `save-cache` is enabled.
         paths:
           - bundle/vendor
 ```

--- a/lib/backends/s3.bash
+++ b/lib/backends/s3.bash
@@ -74,11 +74,11 @@ function restore() {
 
   # Check if prefere local is true and if tar file exists in tmp dir
   if [ "${BK_CACHE_SAVE_CACHE}" == "true" ] && [ -f "${BK_CACHE_LOCAL_PATH}/${TAR_FILE}" ]; then
-    echo -e "${BK_LOG_PREFIX}:file_cabinet: Using previously downloaded file ${BK_CACHE_LOCAL_PATH}/${TAR_FILE} since local is prefered."
+    echo -e "${BK_LOG_PREFIX}🗄️ Using previously downloaded file ${BK_CACHE_LOCAL_PATH}/${TAR_FILE} since local is preferred."
     if tar ${BK_TAR_EXTRACT_ARGS} "${BK_CACHE_LOCAL_PATH}/${TAR_FILE}" -C . ; then
         return
     fi
-    echo -e "${BK_LOG_PREFIX}:file_cabinet: Ignoring corrupted previously downloaded file ${BK_CACHE_LOCAL_PATH}/${TAR_FILE}."
+    echo -e "${BK_LOG_PREFIX}🗄️ Ignoring corrupted previously downloaded file ${BK_CACHE_LOCAL_PATH}/${TAR_FILE}."
   fi
 
   aws s3api head-object --bucket "${BUILDKITE_PLUGIN_CACHE_S3_BUCKET}" --key "${TKEY}/${TAR_FILE}" ${BK_DEFAULT_AWS_ARGS} || no_head=true
@@ -149,7 +149,7 @@ function cache() {
   cache_locating "${TAR_TARGETS}"
 
   if [ $BK_ALWAYS_CACHE == "true" ]; then
-    echo -e "${BK_LOG_PREFIX}:file_cabinet::close: Removing previously found cache ${TAR_FILE} since always is true."
+    echo -e "${BK_LOG_PREFIX}🗄️🗑️ Removing previously found cache ${TAR_FILE} since always is true."
     rm -f "${TAR_FILE}"
   fi
 

--- a/lib/backends/tarball.bash
+++ b/lib/backends/tarball.bash
@@ -115,7 +115,7 @@ function cache() {
   TAR_FILE="${CACHE_PREFIX}/${CACHE_KEY}.${BK_TAR_EXTENSION}"
 
   if [ $BK_ALWAYS_CACHE == "true" ]; then
-    echo -e "${BK_LOG_PREFIX}:file_cabinet::close: Removing previously found cache ${TAR_FILE} since always is true."
+    echo -e "${BK_LOG_PREFIX}🗄️🗑️ Removing previously found cache ${TAR_FILE} since always is true."
     rm -f "${TAR_FILE}"
   fi
 


### PR DESCRIPTION
- Add `save-cache-dir` to README (from https://github.com/nienbo/cache-buildkite-plugin/pull/75)
- Use emojis directly, as they weren't showing. This is how it's done for the magnifying glass.
- Can't find what emoji `:close:` is - but a bin seems appropriate
- Fix typo for `preferred`

![image](https://github.com/user-attachments/assets/382f9e11-4726-447b-9419-76a39063e083)
