### PR TITLE
upload to s3 without local path

### DIFF
--- a/lib/backends/s3.bash
+++ b/lib/backends/s3.bash
@@ -162,6 +162,6 @@ function cache() {
     TMP_FILE="$(mktemp)"
     tar "${BK_TAR_ARGS[@]}" "${TMP_FILE}" ${TAR_TARGETS}
     mv -f "${TMP_FILE}" "${TAR_FILE}"
-    aws s3 cp ${BK_CUSTOM_AWS_ARGS} "${TAR_FILE}" "s3://${BUCKET}/${TAR_FILE}"
+    aws s3 cp ${BK_CUSTOM_AWS_ARGS} "${TAR_FILE}" "s3://${BUCKET}/$(basename "${TAR_FILE}")"
   fi
 }


### PR DESCRIPTION
fixes a bug I introduced in https://github.com/nienbo/cache-buildkite-plugin/issues/76

the cache file was being uploaded to s3 with it's prefix, like `s3://mycache/mnt/cache/cache.tar`