### PR TITLE
create save-cache-dir if not exists when uploading

### DIFF
--- a/lib/backends/s3.bash
+++ b/lib/backends/s3.bash
@@ -138,6 +138,10 @@ function restore() {
 function cache() {
   TAR_FILE="${CACHE_KEY}.${BK_TAR_EXTENSION}"
   if [ "${BK_CACHE_SAVE_CACHE}" == "true" ]; then
+    if [ ! -d "${BK_CACHE_LOCAL_PATH}" ]; then
+      mkdir -p "${BK_CACHE_LOCAL_PATH}"
+    fi
+
     TAR_FILE="${BK_CACHE_LOCAL_PATH}/${TAR_FILE}"
   fi
   BUCKET="${BUILDKITE_PLUGIN_CACHE_S3_BUCKET}/${BUILDKITE_ORGANIZATION_SLUG}/$(pipeline_slug)"


### PR DESCRIPTION
Similar to https://github.com/nienbo/cache-buildkite-plugin/pull/78.

#78 was for creating the local cache directory when downloading (pre-command) if it did not exist. this PR creates the directory to save the local cache directory (post-command)

