### PR TITLE
Support zstd as a compression backend

### DIFF
--- a/lib/backends/s3.bash
+++ b/lib/backends/s3.bash
@@ -33,6 +33,12 @@ if [[ ! "$OSTYPE" == "darwin"* ]]; then
     fi
     BK_TAR_EXTENSION="tar.gz"
     BK_TAR_EXTRACT_ARGS="-xzf"
+
+    if [[ "${BK_CACHE_COMPRESS_PROGRAM}" == zstd ]]; then
+      BK_TAR_EXTENSION="tar.zst"
+      BK_TAR_ARGS=("$BK_TAR_ADDITIONAL_ARGS" --use-compress-program "zstd" -cf)
+      BK_TAR_EXTRACT_ARGS="--use-compress-program zstd -xf"
+    fi
   else
     BK_TAR_ARGS=("$BK_TAR_ADDITIONAL_ARGS" -cf)
   fi

--- a/lib/backends/tarball.bash
+++ b/lib/backends/tarball.bash
@@ -34,6 +34,12 @@ if [[ ! "$OSTYPE" == "darwin"* ]]; then
     fi
     BK_TAR_EXTENSION="tar.gz"
     BK_TAR_EXTRACT_ARGS="-xzf"
+
+    if [[ "${BK_CACHE_COMPRESS_PROGRAM}" == zstd ]]; then
+      BK_TAR_EXTENSION="tar.zst"
+      BK_TAR_ARGS=("$BK_TAR_ADDITIONAL_ARGS" --use-compress-program "zstd" -cf)
+      BK_TAR_EXTRACT_ARGS="--use-compress-program zstd -xf"
+    fi
   else
     BK_TAR_ARGS=("$BK_TAR_ADDITIONAL_ARGS" -cf)
   fi


### PR DESCRIPTION
[zstd](https://github.com/facebook/zstd) is faster at compressing and decompressing than gzip, and results in small files.

We've seen plugin compression + upload times go from 40+ seconds to 6-7 seconds when using zstd compared to gzip, while also having smaller files.