### PR TITLE
fix: avoid mktemp

### DIFF
--- a/lib/backends/s3.bash
+++ b/lib/backends/s3.bash
@@ -120,13 +120,11 @@ function restore() {
   fi
 
   if [[ ! "${BK_AWS_FOUND}" =~ (false) ]]; then
-    TMP_FILE="$(mktemp)"
-    aws s3 cp ${BK_CUSTOM_AWS_ARGS} "s3://${BUCKET}/${TAR_FILE}" "${TMP_FILE}"  || s3_download_failed=true
+    aws s3 cp ${BK_CUSTOM_AWS_ARGS} "s3://${BUCKET}/${TAR_FILE}" "${TAR_FILE}" || s3_download_failed=true
     if ${s3_download_failed:-false}; then
       echo -e "S3 download failed, soft failing and skipping cache restore..."
+      rm -f "${TAR_FILE}"
       return 0
-    else
-      mv -f "${TMP_FILE}" "${TAR_FILE}"
     fi
 
     if [ "${BK_CACHE_SAVE_CACHE}" == "true" ]; then
@@ -169,9 +167,7 @@ function cache() {
   fi
 
   if [ ! -f "$TAR_FILE" ]; then
-    TMP_FILE="$(mktemp)"
-    tar "${BK_TAR_ARGS[@]}" "${TMP_FILE}" ${TAR_TARGETS}
-    mv -f "${TMP_FILE}" "${TAR_FILE}"
+    tar "${BK_TAR_ARGS[@]}" "${TAR_FILE}" ${TAR_TARGETS}
     aws s3 cp ${BK_CUSTOM_AWS_ARGS} "${TAR_FILE}" "s3://${BUCKET}/$(basename "${TAR_FILE}")"
   fi
 }

--- a/lib/backends/tarball.bash
+++ b/lib/backends/tarball.bash
@@ -126,8 +126,6 @@ function cache() {
   fi
 
   if [ ! -f "$TAR_FILE" ]; then
-    TMP_FILE="$(mktemp)"
-    tar "${BK_TAR_ARGS[@]}" "${TMP_FILE}" ${TAR_TARGETS}
-    mv -f "${TMP_FILE}" "${TAR_FILE}"
+    tar "${BK_TAR_ARGS[@]}" "${TAR_FILE}" ${TAR_TARGETS}
   fi
 }

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -10,15 +10,9 @@ setup() {
 }
 
 @test "Pre-command restores cache with basic key" {
-  stub mktemp \
-   " : echo '/tmp/tempfile'"
-
-  stub mv \
-    "-f /tmp/tempfile v1-cache-key.tar : true"
-
   stub aws \
    "s3api head-object --bucket my-bucket --key 'my-org/my-pipeline/v1-cache-key.tar' --profile my-profile : true" \
-   "s3 cp --profile my-profile s3://my-bucket/my-org/my-pipeline/v1-cache-key.tar /tmp/tempfile : echo Copied from S3"
+   "s3 cp --profile my-profile s3://my-bucket/my-org/my-pipeline/v1-cache-key.tar v1-cache-key.tar : echo Copied from S3"
 
   stub tar \
    "-xf v1-cache-key.tar -C . : echo Extracted tar archive"
@@ -45,8 +39,6 @@ setup() {
 
   unstub aws
   unstub tar
-  unstub mv
-  unstub mktemp
 }
 
 @test "Pre-command restores S3 backed cache using local file" {
@@ -84,12 +76,8 @@ setup() {
 
 @test "Post-command syncs artifacts with a single path" {
 
-  stub mktemp \
-   " : echo '/tmp/tempfile'"
   stub tar \
-   "--ignore-failed-read -cf /tmp/tempfile Pods : echo Created tar archive"
-  stub mv \
-    "-f /tmp/tempfile v1-cache-key.tar : true"
+   "--ignore-failed-read -cf v1-cache-key.tar Pods : echo Created tar archive"
   stub aws \
    "s3 cp --profile my-profile v1-cache-key.tar s3://my-bucket/my-org/my-pipeline/v1-cache-key.tar : echo Copied to S3"
 
@@ -116,24 +104,16 @@ setup() {
   unset BUILDKITE_PIPELINE_SLUG
   unset BUILDKITE_ORGANIZATION_SLUG
 
-  unstub mktemp
   unstub tar
-  unstub mv
   unstub aws
 }
 
 @test "Cache key template evaluation on file" {
   CHECKSUM=355831032f586e782b45744f2ed79316cc830244
 
-  stub mktemp \
-   " : echo '/tmp/tempfile'"
-
-  stub mv \
-    "-f /tmp/tempfile v1-cache-key-${CHECKSUM}.tar : true"
-
   stub aws \
    "s3api head-object --bucket my-bucket --key 'my-org/my-pipeline/v1-cache-key-${CHECKSUM}.tar' --profile my-profile : true" \
-   "s3 cp --profile my-profile s3://my-bucket/my-org/my-pipeline/v1-cache-key-${CHECKSUM}.tar /tmp/tempfile : echo Copied from S3"
+   "s3 cp --profile my-profile s3://my-bucket/my-org/my-pipeline/v1-cache-key-${CHECKSUM}.tar v1-cache-key-${CHECKSUM}.tar : echo Copied from S3"
 
   stub tar \
    "-xf v1-cache-key-${CHECKSUM}.tar -C . : echo Extracted tar archive"
@@ -157,8 +137,6 @@ setup() {
   unset BUILDKITE_PIPELINE_SLUG
   unset BUILDKITE_ORGANIZATION_SLUG
 
-  unstub mktemp
-  unstub mv
   unstub aws
   unstub tar
 }
@@ -166,15 +144,9 @@ setup() {
 @test "Cache key template evaluation on dir" {
   CHECKSUM=4cfa4e590847976f26d761074e355e4d95fa8107
 
-  stub mktemp \
-   " : echo '/tmp/tempfile'"
-
-  stub mv \
-    "-f /tmp/tempfile v1-cache-key-${CHECKSUM}.tar : true"
-
   stub aws \
    "s3api head-object --bucket my-bucket --key 'my-org/my-pipeline/v1-cache-key-${CHECKSUM}.tar' --profile my-profile : true" \
-   "s3 cp --profile my-profile s3://my-bucket/my-org/my-pipeline/v1-cache-key-${CHECKSUM}.tar /tmp/tempfile : echo Copied from S3"
+   "s3 cp --profile my-profile s3://my-bucket/my-org/my-pipeline/v1-cache-key-${CHECKSUM}.tar v1-cache-key-${CHECKSUM}.tar : echo Copied from S3"
 
   stub tar \
    "-xf v1-cache-key-${CHECKSUM}.tar -C . : echo Extracted tar archive"
@@ -198,8 +170,6 @@ setup() {
   unset BUILDKITE_PIPELINE_SLUG
   unset BUILDKITE_ORGANIZATION_SLUG
 
-  unstub mktemp
-  unstub mv
   unstub aws
   unstub tar
 }
@@ -207,15 +177,9 @@ setup() {
 @test "Cache key multi-template evaluation" {
   CHECKSUMS=355831032f586e782b45744f2ed79316cc830244-241bc31c8ddc004c48e6d88d7fa51ee981b8ce51
 
-  stub mktemp \
-   " : echo '/tmp/tempfile'"
-
-  stub mv \
-    "-f /tmp/tempfile v1-cache-key-${CHECKSUMS}.tar : true"
-
   stub aws \
    "s3api head-object --bucket my-bucket --key 'my-org/my-pipeline/v1-cache-key-${CHECKSUMS}.tar' --profile my-profile : true" \
-   "s3 cp --profile my-profile s3://my-bucket/my-org/my-pipeline/v1-cache-key-${CHECKSUMS}.tar /tmp/tempfile : echo Copied from S3"
+   "s3 cp --profile my-profile s3://my-bucket/my-org/my-pipeline/v1-cache-key-${CHECKSUMS}.tar v1-cache-key-${CHECKSUMS}.tar : echo Copied from S3"
 
   stub tar \
    "-xf v1-cache-key-${CHECKSUMS}.tar -C . : echo Extracted tar archive"
@@ -239,8 +203,6 @@ setup() {
   unset BUILDKITE_PIPELINE_SLUG
   unset BUILDKITE_ORGANIZATION_SLUG
 
-  unstub mktemp
-  unstub mv
   unstub aws
   unstub tar
 }
@@ -248,15 +210,9 @@ setup() {
 @test "Cache key template evaluation in middle of key" {
   CHECKSUM=355831032f586e782b45744f2ed79316cc830244
 
-  stub mktemp \
-   " : echo '/tmp/tempfile'"
-
-  stub mv \
-    "-f /tmp/tempfile v1-cache-${CHECKSUM}-key.tar : true"
-
   stub aws \
    "s3api head-object --bucket my-bucket --key 'my-org/my-pipeline/v1-cache-$CHECKSUM-key.tar' --profile my-profile : true" \
-   "s3 cp --profile my-profile s3://my-bucket/my-org/my-pipeline/v1-cache-$CHECKSUM-key.tar /tmp/tempfile : echo Copied from S3"
+   "s3 cp --profile my-profile s3://my-bucket/my-org/my-pipeline/v1-cache-$CHECKSUM-key.tar v1-cache-$CHECKSUM-key.tar : echo Copied from S3"
 
   stub tar \
    "-xf v1-cache-$CHECKSUM-key.tar -C . : echo Extracted tar archive"
@@ -280,8 +236,6 @@ setup() {
   unset BUILDKITE_PIPELINE_SLUG
   unset BUILDKITE_ORGANIZATION_SLUG
 
-  unstub mktemp
-  unstub mv
   unstub aws
   unstub tar
 }
@@ -310,15 +264,9 @@ setup() {
 
 @test "S3 arguments are passed through to copy command" {
 
-  stub mktemp \
-   " : echo '/tmp/tempfile'"
-
-  stub mv \
-    "-f /tmp/tempfile v1-cache-key.tar : true"
-
   stub aws \
    "s3api head-object --bucket my-bucket --key 'my-org/my-pipeline/v1-cache-key.tar' --profile my-profile : true" \
-   "s3 cp --profile my-profile --acl bucket-owner-full-control s3://my-bucket/my-org/my-pipeline/v1-cache-key.tar /tmp/tempfile : echo Copied from S3"
+   "s3 cp --profile my-profile --acl bucket-owner-full-control s3://my-bucket/my-org/my-pipeline/v1-cache-key.tar v1-cache-key.tar : echo Copied from S3"
 
   stub tar \
    "-xf v1-cache-key.tar -C . : echo Extracted tar archive"
@@ -344,20 +292,15 @@ setup() {
   unset BUILDKITE_PIPELINE_SLUG
   unset BUILDKITE_ORGANIZATION_SLUG
 
-  unstub mktemp
-  unstub mv
   unstub aws
   unstub tar
 }
 
 @test "S3 download errors cause soft failure" {
 
-  stub mktemp \
-   " : echo '/tmp/tempfile'"
-
   stub aws \
    "s3api head-object --bucket my-bucket --key 'my-org/my-pipeline/v1-cache-key.tar' --profile my-profile : true" \
-   "s3 cp --profile my-profile --acl bucket-owner-full-control s3://my-bucket/my-org/my-pipeline/v1-cache-key.tar /tmp/tempfile : false"
+   "s3 cp --profile my-profile --acl bucket-owner-full-control s3://my-bucket/my-org/my-pipeline/v1-cache-key.tar v1-cache-key.tar : false"
 
   export BUILDKITE_ORGANIZATION_SLUG="my-org"
   export BUILDKITE_PIPELINE_SLUG="my-pipeline"
@@ -379,6 +322,5 @@ setup() {
   unset BUILDKITE_PIPELINE_SLUG
   unset BUILDKITE_ORGANIZATION_SLUG
 
-  unstub mktemp
   unstub aws
 }


### PR DESCRIPTION
Remove patterns of creating a tmpfile (typically in `/tmp`) to only move it when the operation complete. Instead, the operation is done directly on the target file, with a possible fallback to delete the file if a command fails.

The rationale is that `mktemp` creates files in `${TMPDIR:-/tmp}`. On most systems, `/tmp` is a `tmpfs` filesystem with relatively limited space available (especially on lower powered CI machines). This can be an issue if dealing with large artefacts (for example, Rust build artefacts).

Fixes #84 